### PR TITLE
Centered the footer text so that it wasn't way off to the side on larger displays

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -357,6 +357,7 @@ footer {
   padding-bottom: 30px;
   font-size: 13px;
   color: #aaa;
+  text-align: center;
 }
 
 footer a {


### PR DESCRIPTION
The footer text was left aligned to the edge of the viewport.  Since the only text in the footer at the moment is a copyright notice, then it looks decent just being centered.  Aligning it with .inner makes it look misaligned since the headers above it are all outdented.
