### PR TITLE
Stopped internal sidebar links from opening in new tabs/windows

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,6 @@
 <aside id="sidebar">
-  <a href="/why-mentor.html" class="button document" target="_blank">Why Mentoring?</a>
-  <a href="/guidelines.html" class="button document" target="_blank">Mentoring Guidelines</a>
+  <a href="/why-mentor.html" class="button document">Why Mentoring?</a>
+  <a href="/guidelines.html" class="button document">Mentoring Guidelines</a>
   <a href="https://github.com/phpmentoring/phpmentoring.github.com/wiki/Mentors-and-Apprentices" class="button document" target="_blank">
     Sign Up
   </a>


### PR DESCRIPTION
At the moment, whenever you click _any_ link in the sidebar, it opens in a new tab.  This is arguably reasonable for external links, but it really offers a poor user experience when clicking on internal links such as "Mentoring Guidelines" and "Why Mentoring?".

This PR simply removes the target attribute from internal links in the sidebar template to allow for the browser's default behavior to take over.
